### PR TITLE
参加申請取り消し処理

### DIFF
--- a/app/ProjectApplication.php
+++ b/app/ProjectApplication.php
@@ -1,12 +1,14 @@
 <?php
 
 namespace App;
-
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Model;
 
 class ProjectApplication extends Model
 {
-     protected $fillable = [
+    use SoftDeletes;
+    protected $dates = ['deleted_at'];
+    protected $fillable = [
         'project_id', 
         'author_id', 
         'application_id', 

--- a/database/migrations/2021_10_19_150412_add_column_deleted_at_to_project_applications_table.php
+++ b/database/migrations/2021_10_19_150412_add_column_deleted_at_to_project_applications_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnDeletedAtToProjectApplicationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('project_applications', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('project_applications', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+}

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -45,6 +45,16 @@ label {
 .sponly {
     display: none;
 }
+.flash_message {
+    max-width: 1200px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 1rem;
+    background: gray;
+    color: white;
+    margin-bottom: 2rem;
+    opacity: 0.9;
+  }
 @media only screen and (max-width: 768px) {
     .pconly {
         display: none!important;

--- a/resources/views/personal/my_page.blade.php
+++ b/resources/views/personal/my_page.blade.php
@@ -45,7 +45,57 @@
         </div>
         @endforeach
       </div>
-    </div>
+      @if (session('delete_message'))
+        <div class="flash_message">
+            {{ session('delete_message') }}
+        </div>
+        @php session()->forget('delete_message') @endphp
+      @endif
+      
+      {{--自分のページのみ表示--}}
+      @if($display_flag)
+      <p class="mypage_title"><i class="fas fa-clipboard-list icon_color mr1"></i>参加申請中プロジェクト</p>
+      <div class="row">
+        @foreach($now_applications as $key => $now)
+        <div class="col-sm-6 mb2">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title">{{$now->project_name}}</h5>
+              <p class="card-text">{{$now->project_detail}}</p>
+              <a href="#" class="btn btn-primary">このプロジェクトについて</a>
+              <button type="submit" class="btn btn-outline-success" data-toggle="modal" data-target="#cancelModalCenter{{$key}}">参加申請取り消し</button>
+              <!--<a href="/application_list" class="btn btn-primary">参加申請取り消し</a>-->
+            </div>
+          </div>
+        </div>
+        
+        <div class="modal fade" id="cancelModalCenter{{$key}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                {{Form::open(['route' => 'cancel', 'method' => 'post', 'enctype' => 'multipart/form-data'])}}
+              <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalCenterTitle">プロジェクト名 : {{$now->project_name}}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                  <span aria-hidden="true">&times;</span>
+                </button>
+              </div>
+              <div class="modal-body">
+                このプロジェクトへの参加申請をキャンセルしますか？
+              </div>
+              <div class="modal-footer">
+              <input type="hidden" name="project_info" value="{{$now}}">
+                <button type="submit" class="btn btn-primary">参加申請をキャンセルする</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+              </div>
+              {{Form::close()}}
+            </div>
+          </div>
+        </div>{{--closeModal--}}
+        @endforeach
+      </div>
+      @endif
+    </div>{{--myTabContent--}}
+    
     <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">
       <dl class="my_infomations">
         <dt>ユーザー名</dt>

--- a/resources/views/seek_project.blade.php
+++ b/resources/views/seek_project.blade.php
@@ -31,6 +31,12 @@
         </div>
         @php session()->forget('flash_message') @endphp
     @endif
+    @if (session('my_project_message'))
+        <div class="flash_message">
+            {{ session('my_project_message') }}
+        </div>
+        @php session()->forget('my_project_message') @endphp
+    @endif
    <div class="project_list">
         @foreach($projects as $project)
         <!--<div class="project">-->

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,3 +30,4 @@ Route::post('/api/seek_project', 'ApiController@seek_project')->name('seek_proje
 Route::get('/home', 'HomeController@index')->name('home');
 Route::post('/application', 'DynamicController@application')->name('application')->middleware('auth');
 Route::get('/application_list', 'DynamicController@application_list')->name('application_list')->middleware('auth');
+Route::post('/cancel', 'DynamicController@cancel')->name('cancel')->middleware('auth');


### PR DESCRIPTION
参加取り消し対応
論理削除用カラムを追加したので、pull後にphp artisan migrate を実行

また、自分の作成したプロジェクトへは参加申請できないように制御した。
これって今何個でも申請できるけど、同時に申請できるプロジェクト数上限決める？？